### PR TITLE
TASK: Make the package PHP 7.0 compatible

### DIFF
--- a/Classes/ConsoleOutput.php
+++ b/Classes/ConsoleOutput.php
@@ -16,22 +16,22 @@ final class ConsoleOutput
         $this->output = $output;
     }
 
-    public function outputResult(string $result = '', array $arguments = []): void
+    public function outputResult(string $result = '', array $arguments = [])
     {
         $this->output->outputLine('// %s', [\vsprintf($result, $arguments)]);
     }
 
-    public function outputLine(string $text = '', array $arguments = []): void
+    public function outputLine(string $text = '', array $arguments = [])
     {
         $this->output->outputLine($text, $arguments);
     }
 
-    public function outputFormatted(string $text = '', array $arguments = [], int $leftPadding = 0): void
+    public function outputFormatted(string $text = '', array $arguments = [], int $leftPadding = 0)
     {
         $this->output->outputFormatted($text, $arguments, $leftPadding);
     }
 
-    public function outputQuery(array $query): void
+    public function outputQuery(array $query)
     {
         if (isset($query['command'])) {
             $this->outputResult(' <comment>Current query</comment>: %s', [$query['command']]);
@@ -48,7 +48,7 @@ final class ConsoleOutput
         }
     }
 
-    public function outputHeader(): void
+    public function outputHeader()
     {
         $this->output->outputFormatted('Welcome to the <info>EEL</info> shell');
         $this->output->outputFormatted('========================');

--- a/Classes/Handler/ContextHandler.php
+++ b/Classes/Handler/ContextHandler.php
@@ -18,12 +18,12 @@ final class ContextHandler
      */
     protected $eelEvaluationService;
 
-    public function pushAll(array $context): void
+    public function pushAll(array $context)
     {
         $this->context = \array_merge($this->context, $context);
     }
 
-    public function push(string $name, $value): void
+    public function push(string $name, $value)
     {
         $this->context[$name] = $value;
     }

--- a/Classes/Output/ArrayOutput.php
+++ b/Classes/Output/ArrayOutput.php
@@ -12,7 +12,7 @@ final class ArrayOutput extends NodeOutput
     /**
      * @param array $value
      */
-    public function output($value): void
+    public function output($value)
     {
         if (count($value) === 0) {
             $this->output->outputResult(' <comment>Empty result</comment>');

--- a/Classes/Output/FlowQueryOutput.php
+++ b/Classes/Output/FlowQueryOutput.php
@@ -9,7 +9,7 @@ final class FlowQueryOutput extends AbstractOutput
     public static $supportedTypes = [FlowQuery::class];
     public static $priority = 1;
 
-    public function output($value): void
+    public function output($value)
     {
         $this->output->outputResult('<info>Your expression return a FlowQuery, use <b>$query</b> to continue</info>');
     }

--- a/Classes/Output/NodeOutput.php
+++ b/Classes/Output/NodeOutput.php
@@ -13,7 +13,7 @@ class NodeOutput extends AbstractOutput
     /**
      * @param NodeInterface $value
      */
-    public function output($value): void
+    public function output($value)
     {
         $this->outputObjectList([
             $this->extractProperties($value)
@@ -30,7 +30,7 @@ class NodeOutput extends AbstractOutput
         ];
     }
 
-    protected function outputObjectList(array $table): void
+    protected function outputObjectList(array $table)
     {
         foreach ($table as $row) {
             $this->output->outputResult();

--- a/Classes/Output/NodeTypeOutput.php
+++ b/Classes/Output/NodeTypeOutput.php
@@ -12,7 +12,7 @@ final class NodeTypeOutput extends AbstractOutput
     /**
      * @param NodeType $value
      */
-    public function output($value): void
+    public function output($value)
     {
         $this->output->outputResult('<info>NodeType:</info> %s', [$value->getName()]);
     }

--- a/Classes/Output/OutputInterface.php
+++ b/Classes/Output/OutputInterface.php
@@ -6,5 +6,5 @@ use Ttree\EelShell\ConsoleOutput;
 
 interface OutputInterface
 {
-    public function output($value): void;
+    public function output($value);
 }

--- a/Classes/Output/ScalarOutput.php
+++ b/Classes/Output/ScalarOutput.php
@@ -7,7 +7,7 @@ final class ScalarOutput extends AbstractOutput
     public static $supportedTypes = ['boolean', 'integer', 'double', 'string', 'NULL'];
     public static $priority = 1;
 
-    public function output($value): void
+    public function output($value)
     {
         $this->output->outputResult('<info>%s</info>', [$value]);
     }

--- a/Classes/Service/OutputResultService.php
+++ b/Classes/Service/OutputResultService.php
@@ -31,7 +31,7 @@ final class OutputResultService
         $this->registry = static::registration($this->objectManager);
     }
 
-    public function output($value, ConsoleOutput $output): void
+    public function output($value, ConsoleOutput $output)
     {
         $type = \gettype($value);
         if ($type === 'object') {
@@ -45,7 +45,7 @@ final class OutputResultService
         return isset($this->registry[$type], $this->registry[$type][0]['className']);
     }
 
-    protected function outputType(string $type, $value, ConsoleOutput $output): void
+    protected function outputType(string $type, $value, ConsoleOutput $output)
     {
         if (!$this->hasTypeSupport($type)) {
             throw new Exception(\vsprintf('Not output handler for type "%s"', [$type]), 1499164647);

--- a/Classes/Shell.php
+++ b/Classes/Shell.php
@@ -119,7 +119,7 @@ final class Shell
         return sprintf("\${%s}", $expression);
     }
 
-    protected function handleException(\Exception $exception): void
+    protected function handleException(\Exception $exception)
     {
         $this->output->outputLine('Oups, something bad happens ...');
         $this->output->outputLine('<error>%s</error>', [$exception->getMessage()]);


### PR DESCRIPTION
The void return type is available in PHP >= 7.1.
Remove the void return declarations to make the package PHP 7.0 compatible