### PR TITLE
FEATURE: Use context root node as default

### DIFF
--- a/Classes/Command/EelCommandController.php
+++ b/Classes/Command/EelCommandController.php
@@ -27,10 +27,10 @@ class EelCommandController extends CommandController
      *
      * @param string $node Node identifier of the context node
      */
-    public function shellCommand(string $node)
+    public function shellCommand(string $node = '')
     {
         $context = $this->createContentContext('live');
-        $node = $context->getNodeByIdentifier($node);
+        $node = $node ? $context->getNodeByIdentifier($node) : $context->getRootNode();
         $context = [
             'node' => $node,
         ];

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ This shell provide a REPL style EEL expression parser.
 
     composer require ttree/eelshell
     ./flow eel:shell --node e157515b-0fc0-443b-921c-58a630843d63
-    
-The ````node```` argument will be available in the context of your EEL expression.
+
+The ````node```` argument will be available in the context of your EEL expression. If not set, ````node```` will default to the root node of the `live` workspace.
 
 [![asciicast](https://asciinema.org/a/oWFnjjPEtMPsK2mAh8eEBfE44.png)](https://asciinema.org/a/oWFnjjPEtMPsK2mAh8eEBfE44)
 


### PR DESCRIPTION
With this PR, the `--node` parameter becomes optional. If not set, `node` will default to the root node of the live workspace.

This relates somewhat to #3, except that the root node is used instead of the site node. I felt this to be a more natural choice.